### PR TITLE
fix hexdump issue

### DIFF
--- a/boxes/cpp-compile-time-clang/Dockerfile
+++ b/boxes/cpp-compile-time-clang/Dockerfile
@@ -1,10 +1,13 @@
 FROM esolang/cpp-clang
 
+COPY hex.c /tmp/hex.c
 RUN apt-get update -y && \
     apt-get install bsdmainutils -y && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    gcc /tmp/hex.c -o /bin/hex && \
+    rm /tmp/hex.c && \
     ln -s /bin/script /bin/cpp-compile-time-clang
 
 COPY script /root/script

--- a/boxes/cpp-compile-time-clang/hex.c
+++ b/boxes/cpp-compile-time-clang/hex.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+int main() {
+  int c;
+  while ((c=getchar())!=EOF) {
+    printf("\\x%x",(char)c);
+  }
+  return 0;
+}

--- a/boxes/cpp-compile-time-clang/script
+++ b/boxes/cpp-compile-time-clang/script
@@ -6,7 +6,7 @@ cat <<EOF > /tmp/main.cpp
 #include <fstream>
 #include "code.cpp"
 
-constexpr const char* in = "$(cat - | hexdump -e '1/1 "\\x%02x"')";
+constexpr const char* in = "$(cat - | hex)";
 constexpr const char* out = f(in);
 
 int main(int argc, char const *argv[]) {


### PR DESCRIPTION
hexdumpを使うと連続した空白等が*で省略されてしまい、かつ途中に改行が入って、正しく動作しないため、hexプログラムという、入力値をすべて\xYYの形に変形して出力するプログラムを新しく追加して対応した。