### PR TITLE
Add Plain TeX for codegolf battle

### DIFF
--- a/boxes.yml
+++ b/boxes.yml
@@ -613,3 +613,6 @@ ubuntu-base:
 brainfuck-bfi:
   _name: Brainfuck (BFI)
   _link: http://esoteric.sange.fi/brainfuck/impl/interp/BFI.c
+texforgolf:
+  _name: Plain TeX
+  _link: http://texdoc.net/texmf-dist/doc/plain/texbytopic/TeXbyTopic.pdf

--- a/boxes/texforgolf/Dockerfile
+++ b/boxes/texforgolf/Dockerfile
@@ -1,0 +1,64 @@
+# Thanks, Kaito Udagawa san & 3846masa san!
+# Modified for TeX-esolang-battle. (c) 2019 domperor
+# Options reference: munepi san's Qiita
+# => https://qiita.com/munepi/items/f2eaa30f0cd00a9a68f8
+
+# Original Dockerfile is from ......
+# => https://github.com/Paperist/docker-alpine-texlive-ja/blob/master/Dockerfile
+# Copyright (c) 2016 Kaito Udagawa
+# Copyright (c) 2016-2019 3846masa
+# Released under the MIT license
+# https://opensource.org/licenses/MIT
+
+FROM frolvlad/alpine-glibc
+
+COPY script /bin/script
+RUN chmod 744 /bin/script
+WORKDIR /root
+CMD [ "sh" ]
+
+ENV PATH /usr/local/texlive/2019/bin/x86_64-linux:$PATH
+
+RUN apk --no-cache add perl wget xz tar fontconfig-dev freetype-dev && \
+    mkdir /tmp/install-tl-unx && \
+    wget -qO - ftp://tug.org/historic/systems/texlive/2019/install-tl-unx.tar.gz | \
+    tar -xz -C /tmp/install-tl-unx --strip-components=1 && \
+    printf "%s\n" \
+      "selected_scheme scheme-minimal" \
+      "TEXDIR /usr/local/texlive/2019" \
+      "TEXMFLOCAL /usr/local/texlive/texmf-local" \
+      "TEXMFSYSCONFIG /usr/local/texlive/2019/texmf-config" \
+      "TEXMFSYSVAR /usr/local/texlive/2019/texmf-var" \
+      "TEXMFHOME ~/texmf" \
+      "TEXMFCONFIG ~/.texlive2019/texmf-config" \
+      "TEXMFVAR ~/.texlive2019/texmf-var" \
+      "option_doc 0" \
+      "option_src 0" \
+      "binary_x86_64-darwin 0" \
+      "binary_x86_64-linux 1" \
+      "binary_win32 0" \
+      "option_adjustrepo 0" \
+      "option_autobackup 0" \
+      "option_backupdir tlpkg/backups" \
+      "option_desktop_integration 0" \
+      "option_file_assocs 0" \
+      "option_fmt 1" \
+      "option_letter 0" \
+      "option_path 0" \
+      "option_post_code 1" \
+      "option_sys_bin /usr/local/bin" \
+      "option_sys_info /usr/local/share/info" \
+      "option_sys_man /usr/local/share/man" \
+      "option_w32_multi_user 1" \
+      "option_write18_restricted 1" \
+      "portable 0" \
+      > /tmp/install-tl-unx/texlive.profile && \
+    /tmp/install-tl-unx/install-tl \
+      --profile=/tmp/install-tl-unx/texlive.profile && \
+    tlmgr install \
+      collection-basic && \
+    rm -fr /tmp/install-tl-unx && \
+    apk --no-cache del xz tar && \
+    ln -s /bin/script /bin/texforgolf
+
+COPY script /root/script

--- a/boxes/texforgolf/script
+++ b/boxes/texforgolf/script
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cat - > /tmp/stdin.tex
+echo "\openin0=stdin.tex" | cat - $1 > /tmp/code.tex
+cd /tmp
+tex code.tex | sed -e '1,2d' | sed -e '$d' | sed -e '$d' | sed -e '$d'
+rm code.log
+rm code.dvi
+rm code.tex
+rm stdin.tex

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -204,6 +204,7 @@ alias=all:
   - clisp-sbcl
   - abc
   - brainfuck-bfi
+  - texforgolf
 image=base:
   image: esolang/base
   context: boxes/base
@@ -1821,6 +1822,13 @@ image=emacs:
 image=brainfuck-bfi:
   image: esolang/brainfuck-bfi
   context: boxes/brainfuck-bfi
+  tags:
+  - latest
+  - 2.2.0
+  depends: []
+image=texforgolf:
+  image: esolang/texforgolf
+  context: boxes/texforgolf
   tags:
   - latest
   - 2.2.0

--- a/spec/assets/README.md
+++ b/spec/assets/README.md
@@ -1,4 +1,4 @@
-﻿# Hello, World!
+# Hello, World!
 
 Contents under this directory retains their original licenses.
 
@@ -134,6 +134,7 @@ Contents under this directory retains their original licenses.
 * `cat.swift`: Original
 * `cat.taxi`: [BigZaphod](https://github.com/BigZaphod/Taxi/blob/master/examples/echo.txt)
 * `cat.tetris` : Original
+* `cat.tex` : Original
 * `cat.triangularity` : Original
 * `cat.typhon`: Original
 * `cat.unicue`: Original
@@ -301,6 +302,7 @@ Contents under this directory retains their original licenses.
 * `hello.swift`: [developer.apple.com](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/GuidedTour.html)
 * `hello.taxi`: [BigZaphod](https://github.com/BigZaphod/Taxi/blob/master/examples/hello_world.txt)
 * `hello.tetris` : Original
+* `hello.tex` : Original
 * `hello.toadskin`: [esolangs.org](https://esolangs.org/wiki/Hello_world_program_in_esoteric_languages#Toadskin)
 * `hello.triangularity`: [Mr-Xcoder](https://github.com/Mr-Xcoder/Triangularity/blob/master/README.md)
 * `hello.typhon`: [nefo-mi](https://github.com/nefo-mi/Typhon/blob/master/examples/helloworld.ty)

--- a/spec/assets/cat.tex
+++ b/spec/assets/cat.tex
@@ -1,0 +1,3 @@
+\endlinechar=-1\read0 to \inputtext
+\write0{\inputtext}
+\end

--- a/spec/assets/hello.tex
+++ b/spec/assets/hello.tex
@@ -1,0 +1,2 @@
+\write0{Hello, World!}
+\end

--- a/spec/boxes_spec.rb
+++ b/spec/boxes_spec.rb
@@ -1004,4 +1004,9 @@ describe 'esolang-box', v2: true do
     it { expect(result_of(subject, 'hello.bsl')).to eql("Hello, World!") }
     it { expect(result_of(subject, 'cat.bsl', "meow")).to eql("meow") }
   end
+
+  describe 'texforgolf' do
+    it { expect(result_of(subject, 'hello.tex')).to eql("Hello, World!") }
+    it { expect(result_of(subject, 'cat.tex', "meow")).to eql("meow") }
+  end
 end


### PR DESCRIPTION
Adding Plain TeX for codegolf battle
stdinからの読み込みは通常\read-1ですが，動作安定化のため\read0で行われるようにストリームを変えてあります。Plain TeXのみのインストール。LaTeXは使えません。