### PR TITLE
fix bash-busybox

### DIFF
--- a/boxes/bash-busybox/Dockerfile
+++ b/boxes/bash-busybox/Dockerfile
@@ -2,7 +2,7 @@ FROM esolang/bash-pure
 
 RUN mv /opt/jails/bash-pure /opt/jails/bash-busybox && \
     cp /bin/busybox /opt/jails/bash-busybox/bin/busybox && \
-    (ls /bin -l | grep /bin/busybox | awk '{print $9}' | xargs -I{} cp -d /bin/{} /opt/jails/bash-busybox/bin/{}) && \
+    (busybox --list | xargs -I {} ln -s /bin/busybox /opt/jails/bash-busybox/bin/{}) && \
     ln -s /bin/script /bin/bash-busybox && \
     rm /bin/bash-pure
 


### PR DESCRIPTION
- bash-busyboxにおいてtrコマンドが実行できないというissueが起きている
- busyboxコマンド自体は存在しているが、これに含まれるコマンド群がjail内/bin/cmdに入っていないことが原因
- busybox --listで全列挙出来るので、全部lnしました。
  - 副作用として、例えば`tr`を実行するとbusybox実行していることが分かるエラー文を吐きます