### PR TITLE
リンク切れの言語を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ sys     0m 13.73s
         * [`esolang/pure-folders`](https://hub.docker.com/r/esolang/pure-folders/): [Pure Folders](https://esolangs.org/wiki/Folders#Pure_Folders)
     * [`esolang/cmd`](https://hub.docker.com/r/esolang/cmd/): [cmd.exe](https://en.wikipedia.org/wiki/Cmd.exe)
     * [`esolang/lua`](https://hub.docker.com/r/esolang/lua/): [Lua](https://www.lua.org/)
-        * [`esolang/rprogn`](https://hub.docker.com/r/esolang/rprogn/): [Reverse Programmer Notation](https://tehflamintaco.github.io/Reverse-Programmer-Notation/)
+        * [`esolang/rprogn`](https://hub.docker.com/r/esolang/rprogn/): [Reverse Programmer Notation](https://github.com/TehFlaminTaco/Reverse-Programmer-Notation)
     * [`esolang/ocaml`](https://hub.docker.com/r/esolang/ocaml/): [OCaml](http://ocaml.org/)
         * [`esolang/coq`](https://hub.docker.com/r/esolang/coq/): [Coq](https://coq.inria.fr/)
     * [`esolang/haskell`](https://hub.docker.com/r/esolang/haskell/): [Haskell](https://www.haskell.org/)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ sys     0m 13.73s
             * [`esolang/visualbasic-dotnet`](https://hub.docker.com/r/esolang/visualbasic-dotnet/): [Visual Basic (.NET Core)](https://docs.microsoft.com/en-us/dotnet/visual-basic/)
         * [`esolang/fortran`](https://hub.docker.com/r/esolang/fortran/): [Fortran 2018](https://gcc.gnu.org/fortran/)
         * [`esolang/ring`](https://hub.docker.com/r/esolang/ring/): [Ring](http://ring-lang.sourceforge.net/)
-        * [`esolang/snobol`](https://hub.docker.com/r/esolang/snobol/): [SNOBOL4](http://www.snobol4.org/)
+        * [`esolang/snobol`](https://hub.docker.com/r/esolang/snobol/): [SNOBOL4](https://www.regressive.org/snobol4/)
         * [`esolang/cobol`](https://hub.docker.com/r/esolang/cobol/): [COBOL](https://open-cobol.sourceforge.io/)
         * [`esolang/fetlang`](https://hub.docker.com/r/esolang/fetlang/): [Fetlang](https://github.com/fetlang/fetlang)
         * [`esolang/alphabeta`](https://hub.docker.com/r/esolang/alphabeta/): [AlphaBeta](https://esolangs.org/wiki/AlphaBeta)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ sys     0m 13.73s
         * [`esolang/velato`](https://hub.docker.com/r/esolang/velato/): [Velato](https://github.com/rottytooth/Velato)
         * [`esolang/function2d`](https://hub.docker.com/r/esolang/function2d/): [Function](https://esolangs.org/wiki/Funciton)
         * [`esolang/produire`](https://hub.docker.com/r/esolang/produire/): [プロデル](https://rdr.utopiat.net/)
-        * [`esolang/z80`](https://hub.docker.com/r/esolang/z80/): [Z80](https://sites.google.com/site/codegolfingtips/Home/z80)
+        * [`esolang/z80`](https://hub.docker.com/r/esolang/z80/): [Z80](https://codegolf.stackexchange.com/questions/230042/tips-for-golfing-in-z80-or-sm83-machine-code)
         * [`esolang/bubble-sort`](https://hub.docker.com/r/esolang/bubble-sort/): [BubbleSortLanguage](https://github.com/lv100tomato/BubbleSortLanguage)
         * [`esolang/classic-music-theory`](https://hub.docker.com/r/esolang/classic-music-theory/): [ClassicMusicTheoryForProgrammer](https://github.com/lv100tomato/ClassicMusicTheoryForProgrammer)
     * [`esolang/jq`](https://hub.docker.com/r/esolang/jq/): [jq](https://stedolan.github.io/jq/)

--- a/boxes.yml
+++ b/boxes.yml
@@ -394,7 +394,7 @@ base:
       _disasm: true
     z80:
       _name: Z80
-      _link: https://sites.google.com/site/codegolfingtips/Home/z80
+      _link: https://codegolf.stackexchange.com/questions/230042/tips-for-golfing-in-z80-or-sm83-machine-code
       _disasm: true
     bubble-sort:
       _name: BubbleSortLanguage

--- a/boxes.yml
+++ b/boxes.yml
@@ -264,7 +264,7 @@ base:
       _link: http://ring-lang.sourceforge.net/
     snobol:
       _name: SNOBOL4
-      _link: http://www.snobol4.org/
+      _link: https://www.regressive.org/snobol4/
     cobol:
       _name: COBOL
       _link: https://open-cobol.sourceforge.io/

--- a/boxes.yml
+++ b/boxes.yml
@@ -590,7 +590,7 @@ base:
     _link: https://www.lua.org/
     rprogn:
       _name: Reverse Programmer Notation
-      _link: https://tehflamintaco.github.io/Reverse-Programmer-Notation/
+      _link: https://github.com/TehFlaminTaco/Reverse-Programmer-Notation
   ocaml:
     _name: OCaml
     _link: http://ocaml.org/


### PR DESCRIPTION
先日リンク切れしていると指摘があった SNOBOL4, Z80, Reverse Programmer Notation について、新しいURLに更新しました。よろしくお願いします。