### PR TITLE
Coq のビルド失敗を修正

### DIFF
--- a/boxes/coq/Dockerfile
+++ b/boxes/coq/Dockerfile
@@ -1,7 +1,7 @@
 FROM esolang/ocaml
 
 ENV BUILD_PACKAGES="opam m4 make ocaml-findlib build-base gmp mpfr" \
-    RUNTIME_PACKAGES="musl-dev gmp-dev mpfr-dev perl" \
+    RUNTIME_PACKAGES="musl-dev gmp-dev mpfr-dev perl findutils" \
     PATH=/root/.opam/4.10.0/bin:$PATH
 
 RUN rm /bin/ocaml && \


### PR DESCRIPTION
`findutils` が存在しないために Coq のビルドが失敗します。そのため findutils をインストールするように変更しました。よろしくお願いいたします