### PR TITLE
Switch disasm to zorchenhimer/whitespace.git

### DIFF
--- a/boxes/whitespace/Dockerfile
+++ b/boxes/whitespace/Dockerfile
@@ -1,15 +1,15 @@
 FROM esolang/haskell
 
-ENV BUILD_PACKAGES="make musl-dev" \
-    RUNTIME_PACKAGES="libffi python3"
+ENV BUILD_PACKAGES="make go"
 
-RUN apk add --update $BUILD_PACKAGES $RUNTIME_PACKAGES && \
+RUN apk add --update $BUILD_PACKAGES && \
     git clone --depth 1 https://github.com/TryItOnline/WSpace.git /tmp/WSpace && \
     cd /tmp/WSpace && \
     make && \
     cp wspace /usr/bin/whitespace && \
-    curl -L https://github.com/hostilefork/whitespacers/raw/master/python/interpreter.py -o ~/interpreter.py && \
-    sed -i "s/import msvcrt//" ~/interpreter.py && \
+    git clone --depth 1 https://github.com/zorchenhimer/whitespace.git ~/whitespace && \
+    cd ~/whitespace && \
+    make && \
     apk del $BUILD_PACKAGES && \
     rm -rf /var/cache/apk/* /tmp/* && \
     ln -s /bin/script /bin/whitespace

--- a/boxes/whitespace/disasm
+++ b/boxes/whitespace/disasm
@@ -3,5 +3,5 @@
 infile=$(realpath "$1")
 ln -sf "$infile" /tmp/code.ws
 
-/usr/bin/python3 /root/interpreter.py /tmp/code ASM
+/root/whitespace/bin/wt --to-asm /tmp/code.ws
 rm /tmp/code.ws


### PR DESCRIPTION
Solve #69 

Go 言語で書かれているインタプリタ・ディスアセンブラの [zorchenhimer/whitespace](https://github.com/zorchenhimer/whitespace) を使う 
make 後 whitespace ↔ whitespace-asm の変換プログラムが `./bin/wt` に来るので、これを使う