### PR TITLE
Bump compile-time-typescript to 1.4.1

### DIFF
--- a/boxes/compile-time-typescript/Dockerfile
+++ b/boxes/compile-time-typescript/Dockerfile
@@ -5,7 +5,7 @@ ENV BUILD_PACKAGES="npm" \
 
 RUN apk add --update $BUILD_PACKAGES $RUNTIME_PACKAGES && \
     rm /bin/node && \
-    npm install -g compile-time-typescript@1.4.0 && \
+    npm install -g compile-time-typescript@1.4.1 && \
     apk del $BUILD_PACKAGES && \
     rm -rf /var/cache/apk/* /tmp/* && \
     ln -s /bin/script /bin/compile-time-typescript


### PR DESCRIPTION
## Summary
- Bumps `compile-time-typescript` npm package from 1.4.0 to 1.4.1

## Test plan
- [x] Build `compile-time-typescript` Docker image
- [x] Run `bundle exec rspec -t box_id:compile-time-typescript`

🤖 Generated with [Claude Code](https://claude.com/claude-code)