### PR TITLE
Fix box.yaml schema: require expected or expected_file in test cases

### DIFF
--- a/schemas/box.yaml.schema.json
+++ b/schemas/box.yaml.schema.json
@@ -50,7 +50,7 @@
     },
     "credits": {
       "type": "object",
-      "description": "Credits keyed by asset filename",
+      "description": "Credits keyed by asset filename. All files under assets/ must be credited here.",
       "additionalProperties": {
         "type": "string"
       }
@@ -60,6 +60,10 @@
     "test": {
       "type": "object",
       "required": ["file"],
+      "oneOf": [
+        {"required": ["expected"]},
+        {"required": ["expected_file"]}
+      ],
       "additionalProperties": false,
       "properties": {
         "file": {


### PR DESCRIPTION
## Summary

- `test` 定義に `oneOf` を追加し、`expected` または `expected_file` のいずれかを必須属性に変更
- `credits` フィールドの description を更新（軽微な追記）

## Test plan

- [ ] `box.yaml` バリデーションが `expected` / `expected_file` のどちらも指定しない場合にエラーを出すことを確認
- [ ] 既存の `box.yaml` が引き続きバリデーションを通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)