### PR TITLE
Speed up kotlinc startup with AppCDS and TieredStopAtLevel=1

### DIFF
--- a/boxes/kotlin/Dockerfile
+++ b/boxes/kotlin/Dockerfile
@@ -8,4 +8,9 @@ RUN apk add bash && \
     ln -s /bin/script /bin/kotlin && \
     rm /bin/java
 
+RUN JAVA_OPTS="-XX:TieredStopAtLevel=1 -XX:ArchiveClassesAtExit=/root/kotlinc.jsa" \
+    ~/kotlinc/bin/kotlinc -version 2>&1 || true
+
+ENV JAVA_OPTS="-Xmx512M -Xms128M -XX:SharedArchiveFile=/root/kotlinc.jsa -XX:TieredStopAtLevel=1 -Xlog:cds=off"
+
 COPY script /root/script


### PR DESCRIPTION
## Summary

- ビルド時に `kotlinc -version` を実行して AppCDS (Application Class Data Sharing) アーカイブを生成
- 実行時に `-XX:SharedArchiveFile` でアーカイブを使用し、JVM クラスロードを高速化
- `-XX:TieredStopAtLevel=1` で JIT の上位ティアをスキップし、起動時間をさらに削減
- `-Xlog:cds=off` で JDK 25 の動的 CDS が `--enable-native-access` を記録しない既知の制限による非致命的な警告メッセージを抑制

**結果**: `kotlinc` 起動時間が約 3s → 約 1.6s に短縮（全コマンドに適用）

## Test plan

- [x] `docker buildx bake kotlin` でビルド成功を確認
- [x] `docker run esolang/kotlin sh -c "time ~/kotlinc/bin/kotlinc -version"` でエラーなし・約 1.6s 以下を確認
- [x] `bundle exec rspec -t box_id:kotlin` でテスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)