### PR TITLE
Add BASIC (RetroBASIC) box

### DIFF
--- a/boxes/basic-retrobasic/Dockerfile
+++ b/boxes/basic-retrobasic/Dockerfile
@@ -1,0 +1,10 @@
+FROM esolang/ubuntu-base
+
+RUN cd /tmp && \
+    curl -L https://github.com/maurymarkowitz/RetroBASIC/releases/download/v.3.0.2/retrobasic-linux-x86_64.zip -o retrobasic.zip && \
+    unzip retrobasic.zip && \
+    mv retrobasic-linux-x86_64/bin/retrobasic /usr/local/bin/ && \
+    rm -rf /tmp/* && \
+    ln -s /bin/script /bin/basic-retrobasic
+
+COPY script /root/script

--- a/boxes/basic-retrobasic/assets/cat.bas
+++ b/boxes/basic-retrobasic/assets/cat.bas
@@ -1,0 +1,2 @@
+10 LINPUT A$
+20 PRINT A$

--- a/boxes/basic-retrobasic/assets/hello.bas
+++ b/boxes/basic-retrobasic/assets/hello.bas
@@ -1,0 +1,1 @@
+10 PRINT "Hello, World!"

--- a/boxes/basic-retrobasic/box.yaml
+++ b/boxes/basic-retrobasic/box.yaml
@@ -1,0 +1,14 @@
+name: BASIC (RetroBASIC)
+link: "https://github.com/maurymarkowitz/RetroBASIC"
+parent: ubuntu-base
+tests:
+  hello:
+    file: hello.bas
+    expected: "Hello, World!\n"
+  cat:
+    file: cat.bas
+    stdin: "meow\n"
+    expected: "meow\n"
+credits:
+  hello.bas: Original
+  cat.bas: Original

--- a/boxes/basic-retrobasic/script
+++ b/boxes/basic-retrobasic/script
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cat - | retrobasic "$1"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -227,6 +227,7 @@ group "default" {
     "abc",
     "ada",
     "apache2-rewrite",
+    "basic-retrobasic",
     "cpp-clang",
     "cpp-compile-time-clang",
     "crystal",
@@ -2139,6 +2140,14 @@ target "apache2-rewrite" {
     "esolang/ubuntu-base" = "target:ubuntu-base"
   }
   tags = ["esolang/apache2-rewrite:latest", "esolang/apache2-rewrite:2.6.0"]
+}
+
+target "basic-retrobasic" {
+  context = "boxes/basic-retrobasic"
+  contexts = {
+    "esolang/ubuntu-base" = "target:ubuntu-base"
+  }
+  tags = ["esolang/basic-retrobasic:latest", "esolang/basic-retrobasic:2.6.0"]
 }
 
 target "cpp-clang" {


### PR DESCRIPTION
## Summary

- Adds `basic-retrobasic` box using [RetroBASIC](https://github.com/maurymarkowitz/RetroBASIC) 3.0.2
- Uses prebuilt Linux x86_64 binary from official GitHub releases
- Based on `ubuntu-base` (required due to glibc linking)
- Uses `LINPUT` statement for stdin reading (avoids the default `?` prompt from `INPUT`)

## Test plan

- [x] `hello` test: prints `Hello, World!\n`
- [x] `cat` test: reads a line via `LINPUT` and prints it back

🤖 Generated with [Claude Code](https://claude.com/claude-code)